### PR TITLE
Remove `--dev` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Generate vendor patches for packages with single command.
 ## Install
 
 ```bash
-composer require symplify/vendor-patches --dev
+composer require symplify/vendor-patches
 ```
 
 ## Usage


### PR DESCRIPTION
I think most of the developers want to apply there packages on dev and prod deploy. And so I would remove the `--dev` flag from the README. Think cases like where people build phars or other things out of it is more an edgecase and they mostly know themselves that they want then to add it to `--dev` and not prod. Currently unfamiliar devs following the README errors on deploy to a prod system.